### PR TITLE
added description to team section(Volunteers), fixes #441

### DIFF
--- a/index.html
+++ b/index.html
@@ -533,6 +533,12 @@
           <img src="./assets/banner.svg" alt="" class="banner-core" />
         </div>
 
+        <p class="team__description">
+          Iată echipele care, prin dedicarea și implicarea lor, transformă acest vis în realitate. 
+          Fiecare contribuie într-un mod unic și, cu un efort coordonat și o pasiune comună, 
+          aceste echipe arată ce înseamnă să colaborezi pentru un scop mai mare.
+        </p>
+
         <div class="team__members-wrapper">
           <!-- Teams navigation bar -->
           <div class="team__mebers-navbar" id="team-navbar"></div>


### PR DESCRIPTION
- added description to Volunteers sub-section, to better highlight that those links represent the teams contributing to the NGO's projects.
- the paragraphs have different width because of 'text-wrap:balance', I like them like that, it's not a bug :))). But tell me if you prefer consistent width. 
Also, please tell me if you are ok with the text content
![image](https://github.com/user-attachments/assets/f9beb0d0-922b-4f89-9231-fefb6b67d711)
