### PR TITLE
Fix the Cannot stat 'data.json' error and allow the deployment to pro…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "build-css": "node-sass --include-path scss style/style.scss dist/style/style.css",
-    "build": "rm -r dist && mkdir dist && cp index.html dist/index.html && cp details.html dist/details.html && cp 404.html dist/404.html && cp jobCards.js dist/jobCards.js && cp data.json dist/data.json && cp testimonials.json dist/testimonials.json && cp testimonials.js dist/testimonials.js && cp teamMembers.json dist/teamMembers.json && cp details.js dist/details.js && cp teams.js dist/teams.js && cp script.js dist/script.js && cp carousel.js dist/carousel.js && cp -r assets dist/assets && npm run build-css"
+   "build": "rm -r dist && mkdir dist && cp index.html dist/index.html && cp details.html dist/details.html && cp 404.html dist/404.html && cp jobCards.js dist/jobCards.js && cp data/data.json dist/data.json && cp testimonials.json dist/testimonials.json && cp testimonials.js dist/testimonials.js && cp teamMembers.json dist/teamMembers.json && cp details.js dist/details.js && cp teams.js dist/teams.js && cp script.js dist/script.js && cp carousel.js dist/carousel.js && cp -r assets dist/assets && npm run build-css"
   },
   "dependencies": {
     "braces": "^3.0.3",


### PR DESCRIPTION
This commit addresses an issue where the build process was failing because it couldn't locate the JSON data files (data.json, testimonials.json, teamMembers.json) after they were moved to the `data` directory.

The build script in `package.json` has been updated to include the `data/` path when referencing these JSON files in the copy commands. This ensures that the files are correctly located and copied to the `dist` directory during the build process.
